### PR TITLE
Add comment to clarify PayPal salary payment

### DIFF
--- a/main.ledger
+++ b/main.ledger
@@ -543,6 +543,7 @@
     Expenses:Salary                                   $3840.00
     Assets:Bank:Checking
     ; Receipt: db8f3ff3354574b4d24e539b64192aa5.pdf
+    ; For any future clarification, this payment was made through PayPal
 
 2015/05/07 Anonymous Donor 6
     Assets:PayPal                                      $200.00


### PR DESCRIPTION
The IRS requires you to report money paid through PayPal and other third parties separately from your main payments. This comment is for clarification for if we ever go back to our records and wonder why we didn't report Jonathan's April salary in our main tax forms.
